### PR TITLE
fix: harden Communist event guards

### DIFF
--- a/events/moh_china_communism.txt
+++ b/events/moh_china_communism.txt
@@ -22,7 +22,15 @@ china_communism.1 = {
 
 	trigger = {
 		c:CHI ?= this
+		NOR = {
+			has_law = law_type:law_monarchy
+			has_law = law_type:law_theocracy
+			has_law = law_type:law_council_republic
+		}
 		has_global_variable = canton_coup_happened
+		NOT = {
+			exists = c:CCP
+		}
 		NOT = {
 			has_global_variable = ccp_rise_up_happened
 		}
@@ -400,7 +408,7 @@ china_communism.2 = {
 		NOT = {
 			has_global_variable = canton_coup_happened
 		}
-		NOT = {
+		NOR = {
 			has_law = law_type:law_monarchy
 			has_law = law_type:law_theocracy
 			has_law = law_type:law_council_republic


### PR DESCRIPTION
## Summary
- fix the governance-stage guard for `china_communism.2` by using `NOR` instead of a multi-condition `NOT`
- add the same governance-stage guard to `china_communism.1` as a defensive fallback
- prevent `china_communism.1` from trying to create `CCP` when `c:CCP` already exists

## Scope
- touches only `events/moh_china_communism.txt`
- does not add a hard historical year gate, to preserve gameplay pacing
- does not touch `ai_strategies`, `interest_groups`, or broader scripted triggers

## Validation
- `git diff --check`
- simple brace-balance check on `events/moh_china_communism.txt`

Refs #5