### PR TITLE
fix: add one-time event guards

### DIFF
--- a/common/journal_entries/moh_panthay_rebellion.txt
+++ b/common/journal_entries/moh_panthay_rebellion.txt
@@ -7,6 +7,9 @@
 	}
 	possible = {
 		has_global_variable = yunnan_rebellion
+		NOT = {
+			has_global_variable = yunnan_rebellion_complete
+		}
 	}
 	complete = {
 		custom_tooltip = {

--- a/events/moh_xinhai.txt
+++ b/events/moh_xinhai.txt
@@ -410,6 +410,9 @@ xinhai.5 = {
 	icon = "gfx/interface/icons/event_icons/event_fire.dds"
 	duration = 3
 	trigger = {
+		NOT = {
+			has_global_variable = qiujin_dead
+		}
 		any_scope_character = {
 			has_template = chi_qiu_jin_character_template
 		}


### PR DESCRIPTION
## Summary
- add a `qiujin_dead` trigger guard to `xinhai.5`
- add a `yunnan_rebellion_complete` possible guard to `je_panthay_rebellion`

## Scope
- keeps this as a small PR2 slice for one-time event protection
- does not change the broader Xinhai random event pool
- does not touch compatibility-sensitive files

## Validation
- `git diff --check`
- simple brace-balance check on touched files

Refs #5